### PR TITLE
add equals fonction in vector2d and ContinuousAngle

### DIFF
--- a/src/ai/math/ContinuousAngle.cpp
+++ b/src/ai/math/ContinuousAngle.cpp
@@ -121,6 +121,16 @@ double ContinuousAngle::turn() const {
 
 int ContinuousAngle::nb_turn() const {
     return std::trunc( this->angle_value /(2*M_PI) );
+}
+
+bool ContinuousAngle::equals(const ContinuousAngle &angle, double precision)
+{
+    return (std::fabs(this->angle_value - angle.value()) <= precision);
+}
+
+bool ContinuousAngle::notEquals(const ContinuousAngle &angle, double precision)
+{
+    return (std::fabs(this->angle_value - angle.value()) > precision);
 };
 
 bool ContinuousAngle::operator==( const ContinuousAngle& angle ) const {

--- a/src/ai/math/ContinuousAngle.h
+++ b/src/ai/math/ContinuousAngle.h
@@ -25,6 +25,9 @@
 class ContinuousAngle {
 private:
     double angle_value;
+
+    constexpr static const double FLOAT_PRECISION = 0.01;
+
 public:
     ContinuousAngle();
     ContinuousAngle(double angle);
@@ -34,6 +37,7 @@ public:
     ContinuousAngle& operator=( double angle );
     ContinuousAngle& operator=( const ContinuousAngle & angle );
 //    ContinuousAngle& operator=( const Angle & angle );
+
 
     rhoban_utils::Angle angle() const;
     double value() const;
@@ -63,8 +67,11 @@ public:
     double turn() const;
     int nb_turn() const;
 
-    bool operator==( const ContinuousAngle& angle ) const;
-    bool operator!=( const ContinuousAngle& angle ) const;
+    bool equals(const ContinuousAngle& angle, double precision = FLOAT_PRECISION);
+    bool notEquals(const ContinuousAngle& angle, double precision = FLOAT_PRECISION);
+
+    bool operator==( const ContinuousAngle& angle) const;  //unsafe
+    bool operator!=( const ContinuousAngle& angle ) const; //unsafe
     bool operator<( const ContinuousAngle& angle ) const;
     bool operator<=( const ContinuousAngle& angle ) const;
     bool operator>( const ContinuousAngle& angle ) const;

--- a/src/ai/math/vector2d.cpp
+++ b/src/ai/math/vector2d.cpp
@@ -63,6 +63,16 @@ Vector2d point2vector( const rhoban_geometry::Point & p ){
     return Vector2d(p);
 }
 
+bool equals(const Vector2d &v1, const Vector2d &v2, double precision)
+{
+    return (std::fabs(v1[0]-v2[0])<= precision) and (std::fabs(v1[1]-v2[1])<= precision);
+}
+
+bool notEquals(const Vector2d &v1, const Vector2d &v2, double precision)
+{
+    return (std::fabs(v1[0]-v2[0]) > precision) or (std::fabs(v1[1]-v2[1]) > precision);
+}
+
 bool operator==(const Vector2d & v1, const Vector2d & v2){
     return (v1[0] == v2[0]) and (v1[1] == v2[1]);
 }
@@ -195,4 +205,3 @@ std::ostream& operator<<(std::ostream& out, const Vector2d& v){
     out << "[" << v[0] << ", " << v[1] << "]";
     return out;
 }
-

--- a/src/ai/math/vector2d.h
+++ b/src/ai/math/vector2d.h
@@ -57,10 +57,15 @@ class Vector2d {
     Vector2d & operator=( const Vector2d & v );
 
     Vector2d perpendicular();
+
+    constexpr static const double FLOAT_PRECISION = 0.01;
 };
 
 rhoban_geometry::Point vector2point( const Vector2d & v );
 Vector2d point2vector( const rhoban_geometry::Point & p );
+
+bool equals( const Vector2d & v1, const Vector2d & v2, double precision = Vector2d::FLOAT_PRECISION );
+bool notEquals( const Vector2d & v1, const Vector2d & v2, double precision = Vector2d::FLOAT_PRECISION );
 
 bool operator==(const Vector2d & v1, const Vector2d & v2);
 bool operator!=(const Vector2d & v1, const Vector2d & v2);


### PR DESCRIPTION
Dans le dossier math : 
vector2d et ContinuousAngle utilisent des doubles pour stocker leurs variables respectives.
Les deux class définissent les opérateurs : == et != pour l'égalité et la différence.

Dans ce cas si on prend l'exemple suivant pour tester l'égalité de deux angles A et B:
A = 89.99987612
B = 90.00
if ( A == B ) {
   .....
}
renvoie faux, on ne passera jamais dans les accolades alors que l'on peut considérer que A et B sont bien égaux avec une précision à 10 puissance -3.

Ce commit ajoute deux méthodes equals et notEquals qui ajoute une précision pour effectuer une comparaison.

ex : 
if ( A.equals(B, 0.001 ) {
.....
}
